### PR TITLE
Adding `envsubst` to CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install envsubst
+          command: |
+            sudo apt-get update && sudo apt-get -y install gettext-base
+      - run:
           name: envsubst
           command: envsubst < package.json > package.json.tmp && mv package.json.tmp package.json 
       - yarn-install-pretty-lint-tsc-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ jobs:
       - checkout
       - run:
           name: Install envsubst
-          command: |
-            sudo apt-get update && sudo apt-get -y install gettext-base
+          command: sudo apt-get update && sudo apt-get -y install gettext-base
       - run:
           name: envsubst
           command: envsubst < package.json > package.json.tmp && mv package.json.tmp package.json 


### PR DESCRIPTION
We've updated the `cimg/node` version since `backstage-plugin-gkeusage@0.2.5`. This current version does not include `envsubst`. I've added a step in the CCI config to install the package.